### PR TITLE
Stuff

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -13,9 +13,11 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_LESSON_COMMAND = "Unknown lesson command! \n%1$s";
     public static final String MESSAGE_UNKNOWN_CALENDAR_COMMAND = "Unknown calendar command! \n%1$s";
     public static final String MESSAGE_UNKNOWN_TASK_COMMAND = "Unknown task command! \n%1$s";
+    public static final String MESSAGE_UNKNOWN_CMD_COMMAND = "Unknown cmd command! \n%1$s";
 
     public static final String MESSAGE_INVALID_MODULE_DISPLAYED_INDEX = "The module index provided is invalid!";
     public static final String MESSAGE_INVALID_FACILITATOR_DISPLAYED_INDEX =
             "The facilitator index provided is invalid!";
     public static final String MESSAGE_FACILITATORS_LISTED_OVERVIEW = "%1$d facilitators listed!";
+    public static final String MESSAGE_INVALID_CMD_GROUP = "%s group does not exist.";
 }

--- a/src/main/java/seedu/address/logic/commands/calendar/CalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/calendar/CalCommand.java
@@ -14,6 +14,8 @@ import seedu.address.model.Model;
 public abstract class CalCommand extends Command {
 
     public static final List<String> ALL_COMMAND_WORDS = List.of(COMMAND_WORD_VIEW, COMMAND_WORD_FIND);
+    public static final String CAL_VIEW_FORMAT = COMMAND_GROUP_CAL + " " + COMMAND_WORD_VIEW + " this/week";
+    public static final List<String> ALL_COMMAND_FORMATS = List.of(CAL_VIEW_FORMAT);
 
     @Override
     public abstract CommandResult execute(Model model) throws CommandException;

--- a/src/main/java/seedu/address/logic/commands/calendar/CalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/calendar/CalCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands.calendar;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_WEEK;
+
 import java.util.List;
 
 import seedu.address.logic.commands.Command;
@@ -14,7 +16,8 @@ import seedu.address.model.Model;
 public abstract class CalCommand extends Command {
 
     public static final List<String> ALL_COMMAND_WORDS = List.of(COMMAND_WORD_VIEW, COMMAND_WORD_FIND);
-    public static final String CAL_VIEW_FORMAT = COMMAND_GROUP_CAL + " " + COMMAND_WORD_VIEW + " this/week";
+    public static final String CAL_VIEW_FORMAT = COMMAND_GROUP_CAL + " " + COMMAND_WORD_VIEW + " "
+            + PREFIX_WEEK + " this/next";
     public static final List<String> ALL_COMMAND_FORMATS = List.of(CAL_VIEW_FORMAT);
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/calendar/CalViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/calendar/CalViewCommand.java
@@ -12,6 +12,7 @@ import seedu.address.model.calendar.Calendar;
  * Show calendar view to user.
  */
 public class CalViewCommand extends CalCommand {
+
     public static final String MESSAGE_USAGE = COMMAND_GROUP_CAL + " " + COMMAND_WORD_VIEW
             + ": Views the calendar for a week. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/calendar/CalViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/calendar/CalViewCommand.java
@@ -12,7 +12,6 @@ import seedu.address.model.calendar.Calendar;
  * Show calendar view to user.
  */
 public class CalViewCommand extends CalCommand {
-
     public static final String MESSAGE_USAGE = COMMAND_GROUP_CAL + " " + COMMAND_WORD_VIEW
             + ": Views the calendar for a week. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/cmd/CmdGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cmd/CmdGroupCommand.java
@@ -1,13 +1,31 @@
 package seedu.address.logic.commands.cmd;
 
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.calendar.CalCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.facilitator.FacilCommand;
+import seedu.address.logic.commands.lesson.LessonCommand;
+import seedu.address.logic.commands.module.ModuleCommand;
+import seedu.address.logic.commands.task.TaskCommand;
 import seedu.address.model.Model;
 
 /**
  * Lists all commands from a specific command group.
  */
 public class CmdGroupCommand extends CmdCommand {
+
+    public static final String MESSAGE_USAGE = COMMAND_GROUP_CMD + " " + COMMAND_WORD_GROUP
+            + ": Lists all the formats of the specified group of commands.\n"
+            + "Parameters: COMMAND_GROUP\n"
+            + "Examples: " + COMMAND_GROUP_CMD + " " + COMMAND_GROUP_CLASS;
+
+    public static final String MESSAGE_CMD_GROUP_SUCCESS = "%s command group listed: \n%s";
+
     private final String commandGroup;
 
     public CmdGroupCommand(String commandGroup) {
@@ -16,8 +34,57 @@ public class CmdGroupCommand extends CmdCommand {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        // To implement: Returns the correct command group
-        // in a try-catch block, throws Exception when not found group.
-        return null;
+        if (!Command.ALL_COMMAND_GROUPS.contains(commandGroup)) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_CMD_GROUP, commandGroup));
+        }
+
+        switch (commandGroup) {
+        case COMMAND_GROUP_CAL:
+            return new CommandResult(String.format(MESSAGE_CMD_GROUP_SUCCESS, commandGroup,
+                    getCommands(CalCommand.ALL_COMMAND_FORMATS)), CommandType.CMD);
+
+        case COMMAND_GROUP_CLASS:
+            return new CommandResult(String.format(MESSAGE_CMD_GROUP_SUCCESS, commandGroup,
+                    getCommands(LessonCommand.ALL_COMMAND_FORMATS)), CommandType.CMD);
+
+        case COMMAND_GROUP_FACIL:
+            return new CommandResult(String.format(MESSAGE_CMD_GROUP_SUCCESS, commandGroup,
+                    getCommands(FacilCommand.ALL_COMMAND_FORMATS)), CommandType.CMD);
+
+        case COMMAND_GROUP_MOD:
+            return new CommandResult(String.format(MESSAGE_CMD_GROUP_SUCCESS, commandGroup,
+                    getCommands(ModuleCommand.ALL_COMMAND_FORMATS)), CommandType.CMD);
+
+        case COMMAND_GROUP_TASK:
+            return new CommandResult(String.format(MESSAGE_CMD_GROUP_SUCCESS, commandGroup,
+                    getCommands(TaskCommand.ALL_COMMAND_FORMATS)), CommandType.CMD);
+        default:
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_CMD_GROUP, commandGroup));
+        }
+    }
+
+    private String getCommands(List<String> commands) {
+        StringBuilder ret = new StringBuilder();
+
+        for (String str : commands) {
+            ret.append(str).append("\n");
+        }
+
+        return ret.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof CmdGroupCommand)) {
+            return false;
+        }
+
+        CmdGroupCommand e = (CmdGroupCommand) other;
+
+        return this.commandGroup.equals(e.commandGroup);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/module/ModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/module/ModuleCommand.java
@@ -18,9 +18,15 @@ public abstract class ModuleCommand extends Command {
     public static final String ADD_FORMAT = String.format(
             "%s %s %s MOD_CODE [%s DESCRIPTION]",
             COMMAND_GROUP_MOD, COMMAND_WORD_ADD, PREFIX_MODULE_CODE, PREFIX_DESCRIPTION);
-    public static final String DELETE_FORMAT = String.format("%s %s INDEX", COMMAND_GROUP_MOD, COMMAND_WORD_DELETE);
-    public static final String EDIT_FORMAT = String.format(
-            "%s %s [%s MOD_CODE] [%s DESCRIPTION]",
+    public static final String DELETE_FORMAT_INDEX = String.format("%s %s INDEX",
+            COMMAND_GROUP_MOD, COMMAND_WORD_DELETE);
+    public static final String DELETE_FORMAT_MOD_CODE = String.format("%s %s MOD_CODE",
+            COMMAND_GROUP_MOD, COMMAND_WORD_DELETE);
+    public static final String EDIT_FORMAT_INDEX = String.format(
+            "%s %s INDEX %s DESCRIPTION",
+            COMMAND_GROUP_MOD, COMMAND_WORD_EDIT, PREFIX_DESCRIPTION);
+    public static final String EDIT_FORMAT_MOD_CODE = String.format(
+            "%s %s %s MOD_CODE %s DESCRIPTION",
             COMMAND_GROUP_MOD, COMMAND_WORD_EDIT, PREFIX_MODULE_CODE, PREFIX_DESCRIPTION);
     public static final String LIST_FORMAT = String.format("%s %s", COMMAND_GROUP_MOD, COMMAND_WORD_LIST);
     public static final String VIEW_FORMAT = String.format("%s %s MOD_CODE",
@@ -29,7 +35,8 @@ public abstract class ModuleCommand extends Command {
     public static final List<String> ALL_COMMAND_WORDS = List.of(
             COMMAND_WORD_ADD, COMMAND_WORD_DELETE, COMMAND_WORD_EDIT, COMMAND_WORD_LIST, COMMAND_WORD_VIEW);
     public static final List<String> ALL_COMMAND_FORMATS = List.of(
-            ADD_FORMAT, DELETE_FORMAT, EDIT_FORMAT, LIST_FORMAT, VIEW_FORMAT);
+            ADD_FORMAT, DELETE_FORMAT_INDEX, DELETE_FORMAT_MOD_CODE,
+            EDIT_FORMAT_INDEX, EDIT_FORMAT_MOD_CODE, LIST_FORMAT, VIEW_FORMAT);
 
     @Override
     public abstract CommandResult execute(Model model) throws CommandException;

--- a/src/main/java/seedu/address/logic/commands/module/ModuleDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/module/ModuleDeleteCommand.java
@@ -72,6 +72,7 @@ public class ModuleDeleteCommand extends ModuleCommand {
         assert moduleToDelete != null;
         model.deleteModule(moduleToDelete);
         model.deleteModuleCodeFromFacilitatorList(moduleToDelete.getModuleCode());
+        model.deleteTasksWithModuleCode(moduleToDelete.getModuleCode());
 
         if (model.getModule().isPresent() && model.getModule().get().equals(moduleToDelete)) {
             model.updateModule(Optional.empty());

--- a/src/main/java/seedu/address/logic/commands/module/ModuleDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/module/ModuleDeleteCommand.java
@@ -29,6 +29,8 @@ public class ModuleDeleteCommand extends ModuleCommand {
 
     public static final String MESSAGE_DELETE_MODULE_SUCCESS = "Deleted module: %1$s";
 
+    public static final String MESSAGE_DELETE_NON_EXISTENT_MODULE = "%s does not exist.";
+
     private final Index targetIndex;
     private final ModuleCode moduleCode;
 
@@ -69,7 +71,10 @@ public class ModuleDeleteCommand extends ModuleCommand {
             }
         }
 
-        assert moduleToDelete != null;
+        if (moduleToDelete == null) {
+            throw new CommandException(String.format(MESSAGE_DELETE_NON_EXISTENT_MODULE, moduleCode.toString()));
+        }
+
         model.deleteModule(moduleToDelete);
         model.deleteModuleCodeFromFacilitatorList(moduleToDelete.getModuleCode());
         model.deleteTasksWithModuleCode(moduleToDelete.getModuleCode());

--- a/src/main/java/seedu/address/logic/commands/module/ModuleDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/module/ModuleDeleteCommand.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.CommandType;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
 
 /**
  * Deletes a module identified using it's displayed index from Mod Manager.
@@ -22,29 +23,53 @@ public class ModuleDeleteCommand extends ModuleCommand {
     public static final String MESSAGE_USAGE = COMMAND_GROUP_MOD + " " + COMMAND_WORD_DELETE
             + ": Deletes the module identified by the index number used in the displayed module list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_GROUP_MOD + " " + COMMAND_WORD_DELETE + " 1";
+            + "Example: " + COMMAND_GROUP_MOD + " " + COMMAND_WORD_DELETE + " 1\n"
+            + "Parameters: MODULE_CODE (must be a valid module code)\n"
+            + "Example: " + COMMAND_GROUP_MOD + " " + COMMAND_WORD_DELETE + " CS4215";
 
     public static final String MESSAGE_DELETE_MODULE_SUCCESS = "Deleted module: %1$s";
 
     private final Index targetIndex;
+    private final ModuleCode moduleCode;
 
     /**
      * Creates a ModuleDeleteCommand to delete the module the specified {@code index}.
      */
     public ModuleDeleteCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
+
         this.targetIndex = targetIndex;
+        this.moduleCode = null;
+    }
+
+    public ModuleDeleteCommand(ModuleCode moduleCode) {
+        requireNonNull(moduleCode);
+
+        this.moduleCode = moduleCode;
+        this.targetIndex = null;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Module> lastShownList = model.getFilteredModuleList();
+        Module moduleToDelete = null;
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+        if (targetIndex != null && targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_MODULE_DISPLAYED_INDEX);
+        } else if (targetIndex != null) {
+            moduleToDelete = lastShownList.get(targetIndex.getZeroBased());
+        } else { // index == null
+            assert moduleCode != null;
+            for (Module mod : lastShownList) {
+                if (mod.getModuleCode().equals(moduleCode)) {
+                    moduleToDelete = mod;
+                    break;
+                }
+            }
         }
 
-        Module moduleToDelete = lastShownList.get(targetIndex.getZeroBased());
+        assert moduleToDelete != null;
         model.deleteModule(moduleToDelete);
         model.deleteModuleCodeFromFacilitatorList(moduleToDelete.getModuleCode());
 
@@ -59,8 +84,24 @@ public class ModuleDeleteCommand extends ModuleCommand {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof ModuleDeleteCommand // instanceof handles nulls
-                && targetIndex.equals(((ModuleDeleteCommand) other).targetIndex)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ModuleDeleteCommand)) {
+            return false;
+        }
+
+        ModuleDeleteCommand e = (ModuleDeleteCommand) other;
+
+        // similar nullability check
+        boolean indexNull = (targetIndex == null && e.targetIndex == null)
+                || (targetIndex != null && e.targetIndex != null);
+        boolean moduleCodeNull = (moduleCode == null && e.moduleCode == null)
+                || (moduleCode != null && e.moduleCode != null);
+
+        return indexNull && moduleCodeNull
+                && (targetIndex == null || targetIndex.equals(e.targetIndex))
+                && (moduleCode == null || moduleCode.equals(e.moduleCode));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/module/ModuleEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/module/ModuleEditCommand.java
@@ -40,7 +40,7 @@ public class ModuleEditCommand extends ModuleCommand {
             + PREFIX_DESCRIPTION + " SE is love. SE is life";
 
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_NOT_EDITED = "The description to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in Mod Manager.";
     public static final String MESSAGE_NON_EXISTENT_MODULE = "%s does not exist.";
     public static final String MESSAGE_CANNOT_EDIT_MODULE_CODE = "Cannot edit a module's code.";

--- a/src/main/java/seedu/address/logic/commands/module/ModuleEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/module/ModuleEditCommand.java
@@ -30,16 +30,22 @@ public class ModuleEditCommand extends ModuleCommand {
             + "by the index number used in the displayed module list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_MODULE_CODE + " MOD_CODE] "
-            + "[" + PREFIX_DESCRIPTION + " DESCRIPTION]\n"
+            + PREFIX_DESCRIPTION + " DESCRIPTION\n"
             + "Example: " + COMMAND_GROUP_MOD + " " + COMMAND_WORD_EDIT + " 1 "
-            + PREFIX_DESCRIPTION + "new description";
+            + PREFIX_DESCRIPTION + " new description\n"
+            + "Parameters: " + PREFIX_MODULE_CODE + " MOD_CODE "
+            + PREFIX_DESCRIPTION + " DESCRIPTION\n"
+            + "Example: " + COMMAND_GROUP_MOD + " " + COMMAND_WORD_EDIT + " "
+            + PREFIX_MODULE_CODE + " CS2103T "
+            + PREFIX_DESCRIPTION + " SE is love. SE is life";
 
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in Mod Manager.";
+    public static final String MESSAGE_CANNOT_EDIT_MODULE_CODE = "Cannot edit a module's code.";
 
     private final Index index;
+    private final ModuleCode moduleCode;
     private final ModuleEditCommand.EditModuleDescriptor editModuleDescriptor;
 
     /**
@@ -54,18 +60,39 @@ public class ModuleEditCommand extends ModuleCommand {
 
         this.index = index;
         this.editModuleDescriptor = new ModuleEditCommand.EditModuleDescriptor(editModuleDescriptor);
+        this.moduleCode = null;
+    }
+
+    public ModuleEditCommand(ModuleCode moduleCode, ModuleEditCommand.EditModuleDescriptor editModuleDescriptor) {
+        requireNonNull(moduleCode);
+        requireNonNull(editModuleDescriptor);
+
+        this.index = null;
+        this.moduleCode = moduleCode;
+        this.editModuleDescriptor = editModuleDescriptor;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Module> lastShownList = model.getFilteredModuleList();
+        Module moduleToEdit = null;
 
-        if (index.getZeroBased() >= lastShownList.size()) {
+        if (index != null && index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_MODULE_DISPLAYED_INDEX);
+        } else if (index != null) {
+            moduleToEdit = lastShownList.get(index.getZeroBased());
+        } else { // index == null
+            assert moduleCode != null;
+            for (Module mod : lastShownList) {
+                if (mod.getModuleCode().equals(moduleCode)) {
+                    moduleToEdit = mod;
+                    break;
+                }
+            }
         }
 
-        Module moduleToEdit = lastShownList.get(index.getZeroBased());
+        assert moduleToEdit != null;
         Module editedModule = createEditedModule(moduleToEdit, editModuleDescriptor);
 
         if (!moduleToEdit.isSameModule(editedModule) && model.hasModule(editedModule)) {
@@ -114,7 +141,16 @@ public class ModuleEditCommand extends ModuleCommand {
 
         // state check
         ModuleEditCommand e = (ModuleEditCommand) other;
-        return index.equals(e.index)
+
+        // mutual nullability field
+        boolean indexNull = (index == null && e.index == null)
+                || (index != null && e.index != null);
+        boolean moduleCodeNull = (moduleCode == null && e.moduleCode == null)
+                || (moduleCode != null && e.moduleCode != null);
+
+        return indexNull && moduleCodeNull
+                && (index == null || index.equals(e.index))
+                && (moduleCode == null || moduleCode.equals(e.moduleCode))
                 && editModuleDescriptor.equals(e.editModuleDescriptor);
     }
 

--- a/src/main/java/seedu/address/logic/commands/module/ModuleEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/module/ModuleEditCommand.java
@@ -42,6 +42,7 @@ public class ModuleEditCommand extends ModuleCommand {
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in Mod Manager.";
+    public static final String MESSAGE_NON_EXISTENT_MODULE = "%s does not exist.";
     public static final String MESSAGE_CANNOT_EDIT_MODULE_CODE = "Cannot edit a module's code.";
 
     private final Index index;
@@ -92,7 +93,9 @@ public class ModuleEditCommand extends ModuleCommand {
             }
         }
 
-        assert moduleToEdit != null;
+        if (moduleToEdit == null) {
+            throw new CommandException(String.format(MESSAGE_NON_EXISTENT_MODULE, moduleCode.toString()));
+        }
         Module editedModule = createEditedModule(moduleToEdit, editModuleDescriptor);
 
         if (!moduleToEdit.isSameModule(editedModule) && model.hasModule(editedModule)) {

--- a/src/main/java/seedu/address/logic/commands/task/TaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/TaskCommand.java
@@ -5,6 +5,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ON;
 
+import java.util.List;
+
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -22,6 +24,11 @@ public abstract class TaskCommand extends Command {
     public static final String EDIT_FORMAT = String.format("%s %s %s MOD_CODE %s DESCRIPTION %s DATE %s TIME",
             COMMAND_GROUP_TASK, COMMAND_WORD_EDIT,
             PREFIX_MODULE_CODE, PREFIX_DESCRIPTION, PREFIX_ON, PREFIX_AT);
+    public static final String DELETE_FORMAT = String.format("%s %s %s DESCRIPTION",
+            COMMAND_GROUP_TASK, COMMAND_WORD_DELETE,
+            PREFIX_DESCRIPTION);
+
+    public static final List<String> ALL_COMMAND_FORMATS = List.of(ADD_FORMAT, EDIT_FORMAT, DELETE_FORMAT);
 
     @Override
     public abstract CommandResult execute(Model model) throws CommandException;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.parser.calendar.CalCommandParser;
+import seedu.address.logic.parser.cmd.CmdCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.facilitator.FacilCommandParser;
 import seedu.address.logic.parser.lesson.LessonCommandParser;
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case Command.COMMAND_GROUP_TASK:
             return new TaskCommandParser().parse(arguments);
+
+        case Command.COMMAND_GROUP_CMD:
+            return new CmdCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/cmd/CmdCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cmd/CmdCommandParser.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.parser.cmd;
+
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_CMD_COMMAND;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.cmd.CmdCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses cmd commands.
+ * This group of command returns information on other command groups.
+ */
+public class CmdCommandParser implements Parser<CmdCommand> {
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_CMD_COMMAND_FORMAT =
+            Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+
+    @Override
+    public CmdCommand parse(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_CMD_COMMAND_FORMAT.matcher(userInput);
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_CMD_COMMAND, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+
+        switch (commandWord) {
+        case Command.COMMAND_WORD_GROUP:
+            return new CmdGroupCommandParser().parse(arguments);
+        default:
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_CMD_COMMAND, HelpCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/cmd/CmdGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cmd/CmdGroupCommandParser.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.parser.cmd;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.cmd.CmdGroupCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses cmd commands with command word "group".
+ */
+public class CmdGroupCommandParser implements Parser<CmdGroupCommand> {
+    @Override
+    public CmdGroupCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CmdGroupCommand.MESSAGE_USAGE));
+        }
+
+        return new CmdGroupCommand(trimmedArgs);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/module/ModuleDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/module/ModuleDeleteCommandParser.java
@@ -7,6 +7,7 @@ import seedu.address.logic.commands.module.ModuleDeleteCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleCode;
 
 /**
  * Parses input arguments and creates a new ModuleDeleteCommand object.
@@ -19,12 +20,28 @@ public class ModuleDeleteCommandParser implements Parser<ModuleDeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format.
      */
     public ModuleDeleteCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleDeleteCommand.MESSAGE_USAGE));
+        }
+
         try {
             Index index = ParserUtil.parseIndex(args);
             return new ModuleDeleteCommand(index);
         } catch (ParseException pe) {
+            /*
+             This part is left empty intentionally
+             Kinda hack-ish
+             */
+        }
+
+        try {
+            ModuleCode moduleCode = ParserUtil.parseModuleCode(trimmedArgs);
+            return new ModuleDeleteCommand(moduleCode);
+        } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleDeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleDeleteCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/module/ModuleEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/module/ModuleEditCommandParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleCode;
 
 /**
  * Parses input arguments and creates a new ModuleEditCommand object.
@@ -27,19 +28,24 @@ public class ModuleEditCommandParser implements Parser<ModuleEditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULE_CODE, PREFIX_DESCRIPTION);
 
-        Index index;
+        int mode = 0;
 
+        Index index = null;
+
+        ParseException invalidFormatException = null;
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ModuleEditCommand.MESSAGE_USAGE), pe);
+            invalidFormatException = pe;
+            mode = 1;
+        }
+
+        String possibleModCode = argMultimap.getValue(PREFIX_MODULE_CODE);
+        if (mode == 0 && possibleModCode != null) { // using index but mod code exists
+            throw new ParseException(ModuleEditCommand.MESSAGE_CANNOT_EDIT_MODULE_CODE);
         }
 
         ModuleEditCommand.EditModuleDescriptor editModuleDescriptor = new ModuleEditCommand.EditModuleDescriptor();
-        if (argMultimap.getValue(PREFIX_MODULE_CODE) != null) {
-            editModuleDescriptor.setModuleCode(ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE)));
-        }
         if (argMultimap.getValue(PREFIX_DESCRIPTION) != null) {
             editModuleDescriptor.setDescription(ParserUtil.parseDescription(
                     parseFieldForEdit(argMultimap.getValue(PREFIX_DESCRIPTION))));
@@ -49,7 +55,19 @@ public class ModuleEditCommandParser implements Parser<ModuleEditCommand> {
             throw new ParseException(ModuleEditCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new ModuleEditCommand(index, editModuleDescriptor);
+        if (mode == 0) {
+            return new ModuleEditCommand(index, editModuleDescriptor);
+        } else { // User uses no index
+            if (possibleModCode == null) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        ModuleEditCommand.MESSAGE_USAGE), invalidFormatException);
+            }
+            if (!ModuleCode.isValidModuleCode(possibleModCode)) {
+                throw new ParseException(ModuleCode.MESSAGE_CONSTRAINTS);
+            }
+
+            return new ModuleEditCommand(new ModuleCode(possibleModCode), editModuleDescriptor);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/module/ModuleEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/module/ModuleEditCommandParser.java
@@ -29,19 +29,18 @@ public class ModuleEditCommandParser implements Parser<ModuleEditCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULE_CODE, PREFIX_DESCRIPTION);
 
         int mode = 0;
-
         Index index = null;
-
         ParseException invalidFormatException = null;
+        String preamble = argMultimap.getPreamble();
+
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(preamble);
         } catch (ParseException pe) {
             invalidFormatException = pe;
             mode = 1;
         }
 
-        String possibleModCode = argMultimap.getValue(PREFIX_MODULE_CODE);
-        if (mode == 0 && possibleModCode != null) { // using index but mod code exists
+        if (argMultimap.getValue(PREFIX_MODULE_CODE) != null) { // mod code exists
             throw new ParseException(ModuleEditCommand.MESSAGE_CANNOT_EDIT_MODULE_CODE);
         }
 
@@ -58,15 +57,12 @@ public class ModuleEditCommandParser implements Parser<ModuleEditCommand> {
         if (mode == 0) {
             return new ModuleEditCommand(index, editModuleDescriptor);
         } else { // User uses no index
-            if (possibleModCode == null) {
+            if (preamble.equals("") || !ModuleCode.isValidModuleCode(preamble)) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                         ModuleEditCommand.MESSAGE_USAGE), invalidFormatException);
             }
-            if (!ModuleCode.isValidModuleCode(possibleModCode)) {
-                throw new ParseException(ModuleCode.MESSAGE_CONSTRAINTS);
-            }
 
-            return new ModuleEditCommand(new ModuleCode(possibleModCode), editModuleDescriptor);
+            return new ModuleEditCommand(new ModuleCode(preamble), editModuleDescriptor);
         }
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -266,6 +266,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         tasks.remove(key);
     }
 
+    public void removeTasksWithModuleCode(ModuleCode target) {
+        tasks.removeWithModuleCode(target);
+    }
+
     /**
      * Returns the list of modules in this {@code AddressBook}.
      * @return the list of modules.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -24,6 +24,7 @@ public interface Model {
     Predicate<Module> PREDICATE_SHOW_ALL_MODULES = unused -> true;
     Predicate<Task> PREDICATE_SHOW_ALL_TASKS = unused -> true;
     Predicate<Facilitator> PREDICATE_SHOW_NO_FACILITATORS = unused -> false;
+    Predicate<Task> PREDICATE_SHOW_NO_TASKS = unused -> false;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -183,6 +184,12 @@ public interface Model {
      * {@code module} must not already exist in Mod Manager.
      */
     void addTask(Task module);
+
+    /**
+     * Removes all tasks with the specified ModuleCode.
+     * The Module associated with that code is guaranteed to exist before removal.
+     */
+    void deleteTasksWithModuleCode(ModuleCode target);
 
     /**
      * Replaces the given task {@code target} with {@code editedTask}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -36,6 +36,7 @@ public class ModelManager implements Model {
     private final List<Lesson> filteredLesson;
     private Optional<Module> module;
     private final FilteredList<Facilitator> facilitatorsForModule;
+    private final FilteredList<Task> tasksForModule;
     private Calendar calendar;
 
     /**
@@ -56,6 +57,8 @@ public class ModelManager implements Model {
         module = Optional.empty();
         facilitatorsForModule = new FilteredList<>(this.addressBook.getFacilitatorList());
         facilitatorsForModule.setPredicate(PREDICATE_SHOW_NO_FACILITATORS);
+        tasksForModule = new FilteredList<>(this.addressBook.getTaskList());
+        tasksForModule.setPredicate(PREDICATE_SHOW_NO_TASKS);
         calendar = Calendar.getNowCalendar();
     }
 
@@ -333,6 +336,13 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedTask);
 
         addressBook.setTask(target, editedTask);
+    }
+
+    @Override
+    public void deleteTasksWithModuleCode(ModuleCode moduleCode) {
+        requireAllNonNull(moduleCode);
+
+        addressBook.removeTasksWithModuleCode(moduleCode);
     }
 
     //=========== Filtered Task List Accessors =============================================================

--- a/src/main/java/seedu/address/model/facilitator/UniqueFacilitatorList.java
+++ b/src/main/java/seedu/address/model/facilitator/UniqueFacilitatorList.java
@@ -89,29 +89,45 @@ public class UniqueFacilitatorList implements Iterable<Facilitator> {
      * Removes the equivalent module code from the list.
      * The module code must exist in the list.
      */
-    public void removeModuleCode(ModuleCode toRemove) {
+    public void removeModuleCode(final ModuleCode toRemove) {
         requireNonNull(toRemove);
-        List<Facilitator> facilitatorsToDelete = new ArrayList<>();
-        List<Facilitator> facilitatorsToEdit = new ArrayList<>();
-        for (Facilitator facilitator : internalList) {
-            if (facilitator.getModuleCodes().contains(toRemove)) {
-                if (facilitator.getModuleCodes().size() == 1) {
-                    facilitatorsToDelete.add(facilitator);
-                } else {
-                    facilitatorsToEdit.add(facilitator);
-                }
-            }
-        }
-        for (Facilitator facilitator : facilitatorsToDelete) {
-            remove(facilitator);
-        }
-        for (Facilitator facilitator : facilitatorsToEdit) {
-            Set<ModuleCode> moduleCodes = new HashSet<>(facilitator.getModuleCodes());
-            moduleCodes.remove(toRemove);
-            Facilitator editedFacilitator = new Facilitator(facilitator.getName(), facilitator.getPhone(),
-                    facilitator.getEmail(), facilitator.getOffice(), moduleCodes);
-            setFacilitator(facilitator, editedFacilitator);
-        }
+        //        List<Facilitator> facilitatorsToDelete = new ArrayList<>();
+        //        List<Facilitator> facilitatorsToEdit = new ArrayList<>();
+        //        for (Facilitator facilitator : internalList) {
+        //            if (facilitator.getModuleCodes().contains(toRemove)) {
+        //                if (facilitator.getModuleCodes().size() == 1) {
+        //                    facilitatorsToDelete.add(facilitator);
+        //                } else {
+        //                    facilitatorsToEdit.add(facilitator);
+        //                }
+        //            }
+        //        }
+        //        for (Facilitator facilitator : facilitatorsToDelete) {
+        //            remove(facilitator);
+        //        }
+        //        for (Facilitator facilitator : facilitatorsToEdit) {
+        //            Set<ModuleCode> moduleCodes = new HashSet<>(facilitator.getModuleCodes());
+        //            moduleCodes.remove(toRemove);
+        //            Facilitator editedFacilitator = new Facilitator(facilitator.getName(), facilitator.getPhone(),
+        //                    facilitator.getEmail(), facilitator.getOffice(), moduleCodes);
+        //            setFacilitator(facilitator, editedFacilitator);
+        //        }
+
+        List<Facilitator> replacementList = new ArrayList<>();
+        internalList.stream()
+                .filter(facilitator -> {
+                    Set<ModuleCode> temp = facilitator.getModuleCodes();
+                    return temp.contains(toRemove) && temp.size() > 1;
+                })
+                .map(facilitator -> {
+                    Set<ModuleCode> moduleCodes = new HashSet<>(facilitator.getModuleCodes());
+                    moduleCodes.remove(toRemove);
+                    return new Facilitator(facilitator.getName(), facilitator.getPhone(),
+                            facilitator.getEmail(), facilitator.getOffice(), moduleCodes);
+                })
+                .forEach(replacementList::add);
+
+        setFacilitators(replacementList);
     }
 
     /**

--- a/src/main/java/seedu/address/model/facilitator/UniqueFacilitatorList.java
+++ b/src/main/java/seedu/address/model/facilitator/UniqueFacilitatorList.java
@@ -117,13 +117,15 @@ public class UniqueFacilitatorList implements Iterable<Facilitator> {
         internalList.stream()
                 .filter(facilitator -> {
                     Set<ModuleCode> temp = facilitator.getModuleCodes();
-                    return temp.contains(toRemove) && temp.size() > 1;
+                    return !temp.contains(toRemove) || temp.size() > 1;
                 })
                 .map(facilitator -> {
                     Set<ModuleCode> moduleCodes = new HashSet<>(facilitator.getModuleCodes());
-                    moduleCodes.remove(toRemove);
-                    return new Facilitator(facilitator.getName(), facilitator.getPhone(),
-                            facilitator.getEmail(), facilitator.getOffice(), moduleCodes);
+                    boolean hadToRemove = moduleCodes.remove(toRemove);
+                    return hadToRemove
+                            ? new Facilitator(facilitator.getName(), facilitator.getPhone(),
+                            facilitator.getEmail(), facilitator.getOffice(), moduleCodes)
+                            : facilitator;
                 })
                 .forEach(replacementList::add);
 

--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -10,8 +10,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class ModuleCode {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Module codes should be alphanumeric with no spaces and should not exceed 10 characters";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+            "Module codes should be 2-3 letters followed by 4 numbers (and a special letter) "
+                    + "with no spaces and should not exceed 10 characters";
+    public static final String VALIDATION_REGEX = "([a-z,A-Z]{2,3})(\\d{4})([a-z,A-Z]?)";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/address/model/task/UniqueTaskList.java
@@ -3,11 +3,14 @@ package seedu.address.model.task;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.task.exceptions.DuplicateTaskException;
 import seedu.address.model.task.exceptions.TaskNotFoundException;
 
@@ -78,6 +81,19 @@ public class UniqueTaskList implements Iterable<Task> {
         if (!internalList.remove(toRemove)) {
             throw new TaskNotFoundException();
         }
+    }
+
+    /**
+     * Removes tasks with the target ModuleCode.
+     */
+    public void removeWithModuleCode(final ModuleCode target) {
+        Optional<ModuleCode> toCompare = Optional.of(target);
+        List<Task> replacementList = new ArrayList<>();
+        internalList.stream()
+                .filter(task -> task.getModuleCode().equals(toCompare))
+                .forEach(replacementList::add);
+
+        setTasks(replacementList);
     }
 
     public void setTasks(UniqueTaskList replacement) {

--- a/src/main/java/seedu/address/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/address/model/task/UniqueTaskList.java
@@ -90,7 +90,7 @@ public class UniqueTaskList implements Iterable<Task> {
         Optional<ModuleCode> toCompare = Optional.of(target);
         List<Task> replacementList = new ArrayList<>();
         internalList.stream()
-                .filter(task -> task.getModuleCode().equals(toCompare))
+                .filter(task -> !task.getModuleCode().equals(toCompare))
                 .forEach(replacementList::add);
 
         setTasks(replacementList);

--- a/src/test/java/seedu/address/logic/parser/module/ModuleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/module/ModuleCommandParserTest.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.module.ModuleDeleteCommand;
 import seedu.address.logic.commands.module.ModuleEditCommand;
 import seedu.address.logic.commands.module.ModuleListCommand;
 import seedu.address.logic.commands.module.ModuleViewCommand;
+import seedu.address.logic.parser.CliSyntax;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
@@ -48,6 +49,11 @@ public class ModuleCommandParserTest {
                 + INDEX_FIRST.getOneBased() + " "
                 + ModuleUtil.getEditModuleDescriptorDetails(descriptor));
         assertEquals(new ModuleEditCommand(INDEX_FIRST, descriptor), command);
+
+        ModuleEditCommand command1 = (ModuleEditCommand) parser.parse(Command.COMMAND_WORD_EDIT + " "
+                + CliSyntax.PREFIX_MODULE_CODE + " CS2030 "
+                + ModuleUtil.getEditModuleDescriptorDetails(descriptor));
+        assertEquals(new ModuleEditCommand(new ModuleCode("CS2030"), descriptor), command1);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/module/ModuleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/module/ModuleCommandParserTest.java
@@ -15,7 +15,6 @@ import seedu.address.logic.commands.module.ModuleDeleteCommand;
 import seedu.address.logic.commands.module.ModuleEditCommand;
 import seedu.address.logic.commands.module.ModuleListCommand;
 import seedu.address.logic.commands.module.ModuleViewCommand;
-import seedu.address.logic.parser.CliSyntax;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
@@ -50,8 +49,7 @@ public class ModuleCommandParserTest {
                 + ModuleUtil.getEditModuleDescriptorDetails(descriptor));
         assertEquals(new ModuleEditCommand(INDEX_FIRST, descriptor), command);
 
-        ModuleEditCommand command1 = (ModuleEditCommand) parser.parse(Command.COMMAND_WORD_EDIT + " "
-                + CliSyntax.PREFIX_MODULE_CODE + " CS2030 "
+        ModuleEditCommand command1 = (ModuleEditCommand) parser.parse(Command.COMMAND_WORD_EDIT + " CS2030 "
                 + ModuleUtil.getEditModuleDescriptorDetails(descriptor));
         assertEquals(new ModuleEditCommand(new ModuleCode("CS2030"), descriptor), command1);
     }

--- a/src/test/java/seedu/address/logic/parser/module/ModuleDeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/module/ModuleDeleteCommandParserTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.module.ModuleDeleteCommand;
+import seedu.address.model.module.ModuleCode;
 
 public class ModuleDeleteCommandParserTest {
     private ModuleDeleteCommandParser parser = new ModuleDeleteCommandParser();
@@ -15,11 +16,19 @@ public class ModuleDeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new ModuleDeleteCommand(INDEX_FIRST));
+        assertParseSuccess(parser, "CS2030", new ModuleDeleteCommand(new ModuleCode("CS2030")));
+        assertParseSuccess(parser, "CS2040S", new ModuleDeleteCommand(new ModuleCode("CS2040S")));
+        assertParseSuccess(parser, "PCS2030", new ModuleDeleteCommand(new ModuleCode("PCS2030")));
+        assertParseSuccess(parser, "PCS2030T", new ModuleDeleteCommand(new ModuleCode("PCS2030T")));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a",
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-123",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "CS 324",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleDeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/model/module/ModuleCodeTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleCodeTest.java
@@ -32,10 +32,12 @@ public class ModuleCodeTest {
         assertFalse(ModuleCode.isValidModuleCode("cs2103t*")); // contains non-alphanumeric characters
 
         // valid module codes
-        assertTrue(ModuleCode.isValidModuleCode("cs")); // alphabets only
-        assertTrue(ModuleCode.isValidModuleCode("2103T")); // numbers only
-        assertTrue(ModuleCode.isValidModuleCode("cs2103t")); // alphanumeric characters
-        assertTrue(ModuleCode.isValidModuleCode("CS2103T")); // with capital letters
+        // standard NUS module codes
+        assertTrue(ModuleCode.isValidModuleCode("CS1010"));
+        assertTrue(ModuleCode.isValidModuleCode("CS2040S"));
+        assertTrue(ModuleCode.isValidModuleCode("PCS1010"));
+        assertTrue(ModuleCode.isValidModuleCode("PCS1010R"));
+        assertTrue(ModuleCode.isValidModuleCode("CS2103T"));
     }
 
 }

--- a/src/test/java/seedu/address/testutil/EditModuleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditModuleDescriptorBuilder.java
@@ -2,7 +2,6 @@ package seedu.address.testutil;
 
 import seedu.address.logic.commands.module.ModuleEditCommand;
 import seedu.address.model.module.Module;
-import seedu.address.model.module.ModuleCode;
 import seedu.address.model.util.Description;
 
 /**
@@ -25,16 +24,7 @@ public class EditModuleDescriptorBuilder {
      */
     public EditModuleDescriptorBuilder(Module module) {
         descriptor = new ModuleEditCommand.EditModuleDescriptor();
-        descriptor.setModuleCode(module.getModuleCode());
         descriptor.setDescription(module.getDescription());
-    }
-
-    /**
-     * Sets the {@code ModuleCode} of the {@code EditModuleDescriptor} that we are building.
-     */
-    public EditModuleDescriptorBuilder withModuleCode(String moduleCode) {
-        descriptor.setModuleCode(new ModuleCode(moduleCode));
-        return this;
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -194,6 +194,11 @@ public class ModelStub implements Model {
         throw new AssertionError("This method should not be called");
     }
 
+    @Override
+    public void deleteTasksWithModuleCode(ModuleCode target) {
+        throw new AssertionError("This method should not be called");
+    }
+
     /**
      * Replaces the given task {@code target} with {@code editedTask}.
      * {@code target} must exist in Mod Manager.

--- a/src/test/java/seedu/address/testutil/ModuleUtil.java
+++ b/src/test/java/seedu/address/testutil/ModuleUtil.java
@@ -33,8 +33,6 @@ public class ModuleUtil {
      */
     public static String getEditModuleDescriptorDetails(ModuleEditCommand.EditModuleDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getModuleCode().ifPresent(moduleCode -> sb.append(PREFIX_MODULE_CODE)
-                .append(" ").append(moduleCode.value).append(" "));
         descriptor.getDescription().ifPresent(description -> sb.append(PREFIX_DESCRIPTION)
                 .append(" ").append(description.value).append(" "));
         return sb.toString();


### PR DESCRIPTION
- Mod delete/edit can use module code: Mod edit must have the /code prefix, while Mod delete can just type the code.
- Mod delete will delete related tasks (and facilitators with single module) in O(n) time :>
- Cmd group command: kinda trivia ...
- Regex for ModuleCode: CS2030, CS2040S, PCS1101, PCS1101T are all valid - kinda like NUS official mod codes.