### PR TITLE
To parse modules as a chain in facil edit/add

### DIFF
--- a/src/main/java/seedu/address/logic/commands/cmd/CmdAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cmd/CmdAllCommand.java
@@ -7,15 +7,22 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 /**
- * Lists all possible commands.
+ * Lists all possible command groups.
  */
 public class CmdAllCommand extends CmdCommand {
+
+    public static final String MESSAGE_USAGE = COMMAND_GROUP_CMD + " " + COMMAND_WORD_ALL
+            + ": Lists all the command groups available in the system.";
+
+    private final String instruction = "Use " + COMMAND_GROUP_CMD + " " + COMMAND_WORD_GROUP
+            + " COMMAND_GROUP to find out about a particular command group.";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         StringBuilder builder = new StringBuilder();
-
-        Command.ALL_COMMAND_GROUPS.forEach(str -> builder.append(str + " "));
+        builder.append("Here are all available command groups: \n");
+        Command.ALL_COMMAND_GROUPS.forEach(str -> builder.append(str).append(" "));
+        builder.append("\n").append(instruction);
 
         return new CommandResult(builder.toString(), CommandType.CMD);
     }

--- a/src/main/java/seedu/address/logic/commands/cmd/CmdCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cmd/CmdCommand.java
@@ -15,7 +15,7 @@ public abstract class CmdCommand extends Command {
     public static final String ALL_FORMAT = String.format("%s %s", COMMAND_GROUP_CMD, COMMAND_WORD_ALL);
     public static final String GROUP_FORMAT =
             String.format("%s %s COMMAND_GROUP", COMMAND_GROUP_CMD, COMMAND_WORD_GROUP);
-    public static final List<String> ALL_FORMATS = List.of(
+    public static final List<String> ALL_COMMAND_FORMATS = List.of(
             ALL_FORMAT, GROUP_FORMAT);
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/cmd/CmdGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cmd/CmdGroupCommand.java
@@ -58,6 +58,15 @@ public class CmdGroupCommand extends CmdCommand {
         case COMMAND_GROUP_TASK:
             return new CommandResult(String.format(MESSAGE_CMD_GROUP_SUCCESS, commandGroup,
                     getCommands(TaskCommand.ALL_COMMAND_FORMATS)), CommandType.CMD);
+
+        case COMMAND_GROUP_CMD:
+            return new CommandResult(String.format(MESSAGE_CMD_GROUP_SUCCESS, commandGroup,
+                    getCommands(CmdCommand.ALL_COMMAND_FORMATS)), CommandType.CMD);
+
+        case COMMAND_GROUP_EXIT:
+            return new CommandResult(String.format(MESSAGE_CMD_GROUP_SUCCESS, commandGroup,
+                    getCommands(List.of("exit"))), CommandType.CMD);
+
         default:
             throw new CommandException(String.format(Messages.MESSAGE_INVALID_CMD_GROUP, commandGroup));
         }

--- a/src/main/java/seedu/address/logic/commands/facilitator/FacilAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/facilitator/FacilAddCommand.java
@@ -26,8 +26,7 @@ public class FacilAddCommand extends FacilCommand {
             + "[" + PREFIX_PHONE + " PHONE] "
             + "[" + PREFIX_EMAIL + " EMAIL] "
             + "[" + PREFIX_OFFICE + " OFFICE] "
-            + PREFIX_MODULE_CODE + " MOD_CODE "
-            + "[" + PREFIX_MODULE_CODE + " MORE_MOD_CODES]...\n"
+            + PREFIX_MODULE_CODE + " MOD_CODE  + [MORE_MOD_CODES]...\n"
             + "Example: " + COMMAND_GROUP_FACIL + " " + COMMAND_WORD_ADD + " "
             + PREFIX_NAME + " Akshay Narayan "
             + PREFIX_PHONE + " 98765432 "
@@ -39,6 +38,7 @@ public class FacilAddCommand extends FacilCommand {
     public static final String MESSAGE_NOT_ADDED = "At least one of the optional fields must be provided.";
     public static final String MESSAGE_DUPLICATE_FACILITATOR = "This facilitator already exists in Mod Manager.";
     public static final String MESSAGE_MODULE_DOES_NOT_EXIST = "The module %1$s does not exist in Mod Manager.";
+    public static final String MESSAGE_NO_MODULE_CODES_FOUND = "No module codes found";
 
     private final Facilitator toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/facilitator/FacilEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/facilitator/FacilEditCommand.java
@@ -42,7 +42,7 @@ public class FacilEditCommand extends FacilCommand {
             + "[" + PREFIX_PHONE + " PHONE] "
             + "[" + PREFIX_EMAIL + " EMAIL] "
             + "[" + PREFIX_OFFICE + " OFFICE] "
-            + "[" + PREFIX_MODULE_CODE + " MOD_CODE]...\n"
+            + "[" + PREFIX_MODULE_CODE + " MOD_CODES]...\n"
             + "Example: " + COMMAND_GROUP_FACIL + " " + COMMAND_WORD_EDIT + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -51,6 +51,20 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Returns all values of {@code prefix}.
+     * If the prefix does not exist or has no values, this will return an empty list.
+     * Modifying the returned list will not affect the underlying data structure of the ArgumentMultimap.
+     */
+    public String getAllValuesConcat(Prefix prefix) {
+        if (!argMultimap.containsKey(prefix)) {
+            return null;
+        }
+        ArrayList<String> temp = new ArrayList<>(argMultimap.get(prefix));
+
+        return temp.stream().reduce("", (x, y) -> x + " " + y);
+    }
+
+    /**
      * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
      */
     public String getPreamble() {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -157,6 +157,22 @@ public class ParserUtil {
         requireNonNull(moduleCodes);
         final Set<ModuleCode> moduleCodeSet = new HashSet<>();
         for (String moduleCode : moduleCodes) {
+            if (moduleCode.length() > 10) {
+                moduleCodeSet.addAll(parseModuleCodes(moduleCode.split("\\s+")));
+            } else {
+                moduleCodeSet.add(parseModuleCode(moduleCode));
+            }
+        }
+        return moduleCodeSet;
+    }
+
+    /**
+     * Parses {@code String... moduleCodes} into a {@code Set<ModuleCode>}.
+     */
+    public static Set<ModuleCode> parseModuleCodes(String... moduleCodes) throws ParseException {
+        requireNonNull(moduleCodes);
+        final Set<ModuleCode> moduleCodeSet = new HashSet<>();
+        for (String moduleCode : moduleCodes) {
             moduleCodeSet.add(parseModuleCode(moduleCode));
         }
         return moduleCodeSet;

--- a/src/main/java/seedu/address/logic/parser/cmd/CmdAllCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cmd/CmdAllCommandParser.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.parser.cmd;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.cmd.CmdAllCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses cmd commands with command group "all".
+ */
+public class CmdAllCommandParser implements Parser<CmdAllCommand> {
+    @Override
+    public CmdAllCommand parse(String args) throws ParseException {
+        if (!args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CmdAllCommand.MESSAGE_USAGE));
+        }
+
+        return new CmdAllCommand();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/cmd/CmdCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cmd/CmdCommandParser.java
@@ -35,6 +35,8 @@ public class CmdCommandParser implements Parser<CmdCommand> {
         switch (commandWord) {
         case Command.COMMAND_WORD_GROUP:
             return new CmdGroupCommandParser().parse(arguments);
+        case Command.COMMAND_WORD_ALL:
+            return new CmdAllCommandParser().parse(arguments);
         default:
             throw new ParseException(String.format(MESSAGE_UNKNOWN_CMD_COMMAND, HelpCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/facilitator/FacilEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/facilitator/FacilEditCommandParser.java
@@ -75,7 +75,7 @@ public class FacilEditCommandParser implements Parser<FacilEditCommand> {
      * Parses {@code Collection<String> moduleCodes} into a {@code Set<ModuleCode>} if {@code moduleCodes} is non-empty.
      */
     private Optional<Set<ModuleCode>> parseModuleCodesForEdit(Collection<String> moduleCodes) throws ParseException {
-        assert moduleCodes != null;
+        requireNonNull(moduleCodes);
 
         if (moduleCodes.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/seedu/address/model/task/ScheduledTask.java
+++ b/src/main/java/seedu/address/model/task/ScheduledTask.java
@@ -64,13 +64,15 @@ public class ScheduledTask extends Task {
     }
 
     @Override
-    public boolean isSameTask(Task other) {
-        if (other instanceof NonScheduledTask) {
+    public boolean isSameTask(Task obj) {
+        if (obj instanceof NonScheduledTask) {
             return false;
         }
 
+        ScheduledTask other = (ScheduledTask) obj;
+
         return this.description.equals(other.getDescription())
-                && this.taskDateTime.equals(other.getTaskDateTime())
+                && this.taskDateTime.equals(other.taskDateTime)
                 && this.moduleCode.equals(other.getModuleCode());
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -30,6 +30,9 @@ public class CommandTestUtil {
 
     public static final String VALID_MODULE_CODE_CS2103T = "CS2103T";
     public static final String VALID_MODULE_CODE_CS2101 = "CS2101";
+    public static final String VALID_MODULE_CODE_CS4215 = "CS3230";
+    public static final String VALID_MODULE_CODE_CS3230 = "CS4215";
+    public static final String VALID_MODULE_CODES_CHAIN = "CS2101 CS2103T    CS4215  CS3230  ";
     public static final String VALID_DESCRIPTION_CS2103T = "Software Engineering";
     public static final String VALID_DESCRIPTION_CS2101 = "Effective Communication for Computing Professionals";
     public static final String VALID_NAME_AMY = "Amy Bee";
@@ -43,6 +46,7 @@ public class CommandTestUtil {
 
     public static final String MODULE_CODE_DESC_CS2103T = " " + PREFIX_MODULE_CODE + " " + VALID_MODULE_CODE_CS2103T;
     public static final String MODULE_CODE_DESC_CS2101 = " " + PREFIX_MODULE_CODE + " " + VALID_MODULE_CODE_CS2101;
+    public static final String MODULE_CODE_CHAIN = " " + PREFIX_MODULE_CODE + " " + VALID_MODULE_CODES_CHAIN;
     public static final String DESCRIPTION_DESC_CS2103T = " " + PREFIX_DESCRIPTION + " " + VALID_DESCRIPTION_CS2103T;
     public static final String DESCRIPTION_DESC_CS2101 = " " + PREFIX_DESCRIPTION + " " + VALID_DESCRIPTION_CS2101;
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + " " + VALID_NAME_AMY;

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -206,7 +206,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseModuleCodes_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseModuleCodes(null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseModuleCodes((String) null));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/facilitator/FacilAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/facilitator/FacilAddCommandParserTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_CODE_D
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_OFFICE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_CODE_CHAIN;
 import static seedu.address.logic.commands.CommandTestUtil.MODULE_CODE_DESC_CS2101;
 import static seedu.address.logic.commands.CommandTestUtil.MODULE_CODE_DESC_CS2103T;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
@@ -21,6 +22,8 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_CS2101;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_CS2103T;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_CS3230;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_CS4215;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_OFFICE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -68,11 +71,13 @@ public class FacilAddCommandParserTest {
                 + OFFICE_DESC_BOB + MODULE_CODE_DESC_CS2101, new FacilAddCommand(expectedFacilitator));
 
         // multiple module codes - all accepted
-        Facilitator expectedFacilitatorMultipleModuleCodes = new FacilitatorBuilder(BOB)
-                .withModuleCodes(VALID_MODULE_CODE_CS2101, VALID_MODULE_CODE_CS2103T).build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + OFFICE_DESC_BOB
-                        + MODULE_CODE_DESC_CS2103T + MODULE_CODE_DESC_CS2101,
-                new FacilAddCommand(expectedFacilitatorMultipleModuleCodes));
+        // chain of modules
+        Facilitator expectedWithChain = new FacilitatorBuilder(BOB)
+                .withModuleCodes(VALID_MODULE_CODE_CS2101, VALID_MODULE_CODE_CS2103T,
+                        VALID_MODULE_CODE_CS4215, VALID_MODULE_CODE_CS3230)
+                .build();
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + OFFICE_DESC_BOB + MODULE_CODE_CHAIN, new FacilAddCommand(expectedWithChain));
     }
 
     @Test


### PR DESCRIPTION
- The funny thing is: multiple instances of /code prefixes still work. They'll join and try to "split" into codes and parse.