### PR TITLE
facil edit and delete to work with partially correct names

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -19,6 +19,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_FACILITATOR_DISPLAYED_INDEX =
             "The facilitator index provided is invalid!";
     public static final String MESSAGE_FACILITATORS_LISTED_OVERVIEW = "%1$d facilitators listed!";
+    public static final String MESSAGE_FACILITATOR_NOT_FOUND = "Facilitator %s does not exist in Mod Manager.";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
     public static final String MESSAGE_TASKS_FILTERED_OVERVIEW = "%1$d tasks matched your query! "
             + "Type `task list` to return to the main task list.";

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -18,6 +18,10 @@ public class Messages {
     public static final String MESSAGE_INVALID_MODULE_DISPLAYED_INDEX = "The module index provided is invalid!";
     public static final String MESSAGE_INVALID_FACILITATOR_DISPLAYED_INDEX =
             "The facilitator index provided is invalid!";
+    public static final String MESSAGE_PARTIAL_FACILITATOR_NAME_MATCHING_FOUND =
+            "Facilitator %s cannot be found, or isn't unique. But here are the ones that are close to your query:\n";
+    public static final String MESSAGE_ASK_TO_CONFIRM_FACILITATOR =
+            "Please input the exact facilitator you want to delete.";
     public static final String MESSAGE_FACILITATORS_LISTED_OVERVIEW = "%1$d facilitators listed!";
     public static final String MESSAGE_FACILITATOR_NOT_FOUND = "Facilitator %s does not exist in Mod Manager.";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -4,5 +4,5 @@ package seedu.address.logic.commands;
  * Represents the different types of commands.
  */
 public enum CommandType {
-    MODULE, LESSON, TASK, FACILITATOR, CALENDAR, CLEAR, HELP, EXIT, CMD;
+    MODULE, LESSON, TASK, FACILITATOR, CALENDAR, CLEAR, HELP, EXIT, CMD, PROMPTING
 }

--- a/src/main/java/seedu/address/logic/commands/facilitator/FacilDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/facilitator/FacilDeleteCommand.java
@@ -4,16 +4,17 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CommandType;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.facilitator.Facilitator;
 import seedu.address.model.facilitator.Name;
-import seedu.address.model.facilitator.NameContainsKeywordsPredicate;
 
 /**
  * Deletes a facilitator identified using it's displayed index from Mod Manager.
@@ -62,7 +63,10 @@ public class FacilDeleteCommand extends FacilCommand {
 
             if (fetch.isEmpty()) {
                 // No facilitators with such name, so ask the user to confirm
-                NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(List.of(fname.toString()));
+                final List<String> words = List.of(fname.fullName.split("\\s+"));
+                Predicate<Facilitator> predicate =
+                    f -> words.stream().anyMatch(x -> StringUtil.containsWordIgnoreCase(f.getName().fullName, x));
+
                 lastShownList.stream().filter(predicate).forEach(fetch::add);
 
                 if (fetch.isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/facilitator/FacilDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/facilitator/FacilDeleteCommand.java
@@ -27,9 +27,9 @@ public class FacilDeleteCommand extends FacilCommand {
 
     public static final String MESSAGE_DELETE_FACILITATOR_SUCCESS = "Deleted Facilitator: %1$s";
 
-    private final String MESSAGE_PARTIAL_MATCHING_FOUND =
+    public static final String MESSAGE_PARTIAL_MATCHING_FOUND =
             "Facilitator %s cannot be found, or isn't unique. But here are the ones that are close to your query:\n";
-    private final String MESSAGE_ASK_TO_CONFIRM = "\nPlease input the exact facilitator you want to delete.";
+    public static final String MESSAGE_ASK_TO_CONFIRM = "\nPlease input the exact facilitator you want to delete.";
 
     private final Index targetIndex;
     private final Name fname;
@@ -70,7 +70,7 @@ public class FacilDeleteCommand extends FacilCommand {
                 lastShownList.stream().filter(predicate).forEach(fetch::add);
 
                 if (fetch.isEmpty()) {
-                     throw new CommandException(String.format(Messages.MESSAGE_FACILITATOR_NOT_FOUND, fname));
+                    throw new CommandException(String.format(Messages.MESSAGE_FACILITATOR_NOT_FOUND, fname));
                 }
 
                 return promptUserToConfirm(fetch);
@@ -85,6 +85,9 @@ public class FacilDeleteCommand extends FacilCommand {
                 CommandType.FACILITATOR);
     }
 
+    /**
+     * Returns a CommandResult with type PROMPTING, asking the user to input the more precise information.
+     */
     private CommandResult promptUserToConfirm(List<Facilitator> fetch) {
         StringBuilder builder = new StringBuilder(String.format(MESSAGE_PARTIAL_MATCHING_FOUND, fname));
         fetch.forEach(x -> builder.append("   ").append(x.getName().toString()).append('\n'));

--- a/src/main/java/seedu/address/logic/commands/facilitator/FacilDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/facilitator/FacilDeleteCommand.java
@@ -27,10 +27,6 @@ public class FacilDeleteCommand extends FacilCommand {
 
     public static final String MESSAGE_DELETE_FACILITATOR_SUCCESS = "Deleted Facilitator: %1$s";
 
-    public static final String MESSAGE_PARTIAL_MATCHING_FOUND =
-            "Facilitator %s cannot be found, or isn't unique. But here are the ones that are close to your query:\n";
-    public static final String MESSAGE_ASK_TO_CONFIRM = "\nPlease input the exact facilitator you want to delete.";
-
     private final Index targetIndex;
     private final Name fname;
 
@@ -89,9 +85,10 @@ public class FacilDeleteCommand extends FacilCommand {
      * Returns a CommandResult with type PROMPTING, asking the user to input the more precise information.
      */
     private CommandResult promptUserToConfirm(List<Facilitator> fetch) {
-        StringBuilder builder = new StringBuilder(String.format(MESSAGE_PARTIAL_MATCHING_FOUND, fname));
+        StringBuilder builder = new StringBuilder(
+                String.format(Messages.MESSAGE_PARTIAL_FACILITATOR_NAME_MATCHING_FOUND, fname));
         fetch.forEach(x -> builder.append("   ").append(x.getName().toString()).append('\n'));
-        builder.append(MESSAGE_ASK_TO_CONFIRM);
+        builder.append(Messages.MESSAGE_ASK_TO_CONFIRM_FACILITATOR);
         return new CommandResult(builder.toString(), CommandType.PROMPTING);
     }
 

--- a/src/main/java/seedu/address/logic/commands/facilitator/FacilEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/facilitator/FacilEditCommand.java
@@ -14,10 +14,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CommandType;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -25,7 +27,6 @@ import seedu.address.model.Model;
 import seedu.address.model.facilitator.Email;
 import seedu.address.model.facilitator.Facilitator;
 import seedu.address.model.facilitator.Name;
-import seedu.address.model.facilitator.NameContainsKeywordsPredicate;
 import seedu.address.model.facilitator.Office;
 import seedu.address.model.facilitator.Phone;
 import seedu.address.model.module.ModuleCode;
@@ -116,7 +117,10 @@ public class FacilEditCommand extends FacilCommand {
 
             if (fetch.isEmpty()) {
                 // No facilitators with such name, so ask the user to confirm
-                NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(List.of(fname.toString()));
+                final List<String> words = List.of(fname.fullName.split("\\s+"));
+                Predicate<Facilitator> predicate =
+                    f -> words.stream().anyMatch(x -> StringUtil.containsWordIgnoreCase(f.getName().fullName, x));
+
                 lastShownList.stream().filter(predicate).forEach(fetch::add);
 
                 if (fetch.isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/facilitator/FacilEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/facilitator/FacilEditCommand.java
@@ -174,7 +174,15 @@ public class FacilEditCommand extends FacilCommand {
 
         // state check
         FacilEditCommand e = (FacilEditCommand) other;
-        return index.equals(e.index)
+        if ((index != null && e.index == null) || (index == null && e.index != null)) {
+            return false;
+        }
+        if ((fname != null && e.fname == null) || (fname == null && e.fname != null)) {
+            return false;
+        }
+
+        return (index == null || index.equals(e.index))
+                && (fname == null || fname.equals(e.fname))
                 && editFacilitatorDescriptor.equals(e.editFacilitatorDescriptor);
     }
 

--- a/src/main/java/seedu/address/logic/parser/facilitator/FacilDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/facilitator/FacilDeleteCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser.facilitator;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
@@ -7,6 +8,7 @@ import seedu.address.logic.commands.facilitator.FacilDeleteCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.facilitator.Name;
 
 /**
  * Parses input arguments and creates a new FacilDeleteCommand object.
@@ -19,12 +21,19 @@ public class FacilDeleteCommandParser implements Parser<FacilDeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format.
      */
     public FacilDeleteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
         try {
             Index index = ParserUtil.parseIndex(args);
             return new FacilDeleteCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FacilDeleteCommand.MESSAGE_USAGE), pe);
+        } catch (ParseException ignored) {
+            try {
+                Name fname = ParserUtil.parseName(args);
+                return new FacilDeleteCommand(fname);
+            } catch (ParseException pe) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FacilDeleteCommand.MESSAGE_USAGE), pe);
+            }
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/facilitator/FacilEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/facilitator/FacilEditCommandParser.java
@@ -47,7 +47,6 @@ public class FacilEditCommandParser implements Parser<FacilEditCommand> {
         try {
             index = ParserUtil.parseIndex(preAmble);
         } catch (ParseException pe) {
-//            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FacilEditCommand.MESSAGE_USAGE), pe);
             mode = 1;
         }
 

--- a/src/main/java/seedu/address/logic/parser/facilitator/FacilEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/facilitator/FacilEditCommandParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.facilitator.Name;
 import seedu.address.model.module.ModuleCode;
 
 /**
@@ -36,12 +37,26 @@ public class FacilEditCommandParser implements Parser<FacilEditCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
                 args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_OFFICE, PREFIX_MODULE_CODE);
 
-        Index index;
+        String preAmble = argMultimap.getPreamble();
+        Index index = null;
+        Name fname = null;
+
+        int mode = 0;
+        ParseException pE = null;
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(preAmble);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FacilEditCommand.MESSAGE_USAGE), pe);
+//            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FacilEditCommand.MESSAGE_USAGE), pe);
+            mode = 1;
+        }
+
+        try {
+            if (mode == 1) {
+                fname = ParserUtil.parseName(preAmble);
+            }
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FacilEditCommand.MESSAGE_USAGE));
         }
 
         FacilEditCommand.EditFacilitatorDescriptor editFacilitatorDescriptor =
@@ -68,7 +83,11 @@ public class FacilEditCommandParser implements Parser<FacilEditCommand> {
             throw new ParseException(FacilEditCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new FacilEditCommand(index, editFacilitatorDescriptor);
+        if (mode == 0) {
+            return new FacilEditCommand(index, editFacilitatorDescriptor);
+        } else {
+            return new FacilEditCommand(fname, editFacilitatorDescriptor);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/facilitator/FacilEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/facilitator/FacilEditCommandParser.java
@@ -42,7 +42,6 @@ public class FacilEditCommandParser implements Parser<FacilEditCommand> {
         Name fname = null;
 
         int mode = 0;
-        ParseException pE = null;
 
         try {
             index = ParserUtil.parseIndex(preAmble);

--- a/src/main/java/seedu/address/model/facilitator/Name.java
+++ b/src/main/java/seedu/address/model/facilitator/Name.java
@@ -10,13 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should start with alphabetical characters, followed by only alphanumeric characters and spaces,"
+                    + " and should not be blank.";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alnum} ]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -5,6 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -35,8 +36,10 @@ public class CommandBox extends UiPart<Region> {
     @FXML
     private void handleCommandEntered() {
         try {
-            commandExecutor.execute(commandTextField.getText());
-            commandTextField.setText("");
+            CommandResult cmdRes = commandExecutor.execute(commandTextField.getText());
+            if (cmdRes.getType() != CommandType.PROMPTING) {
+                commandTextField.setText("");
+            }
         } catch (CommandException | ParseException e) {
             String txt = commandTextField.getText();
             if (txt.equals(cached)) {

--- a/src/test/java/seedu/address/logic/parser/facilitator/FacilDeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/facilitator/FacilDeleteCommandParserTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.facilitator.FacilDeleteCommand;
+import seedu.address.model.facilitator.Name;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -22,11 +23,14 @@ public class FacilDeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new FacilDeleteCommand(INDEX_FIRST));
+        assertParseSuccess(parser, "Akshay", new FacilDeleteCommand(new Name("Akshay")));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a",
+        assertParseFailure(parser, "1a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FacilDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FacilDeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/facilitator/FacilEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/facilitator/FacilEditCommandParserTest.java
@@ -57,13 +57,11 @@ public class FacilEditCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
-        // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
-
         // no field specified
         assertParseFailure(parser, "1", FacilEditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, VALID_NAME_AMY, FacilEditCommand.MESSAGE_NOT_EDITED);
 
-        // no index and no field specified
+        // no index or name and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }
 

--- a/src/test/java/seedu/address/model/facilitator/NameTest.java
+++ b/src/test/java/seedu/address/model/facilitator/NameTest.java
@@ -29,10 +29,11 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("12345")); // numbers only
+        assertFalse(Name.isValidName("12 peter")); // contains non-alphanumeric characters
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names


### PR DESCRIPTION
- User still needs to input a "correct" partial name like with search.
- System will output a pseudo-prompting (pseudo as user can just ignore and sth else) to ask for a correct name input. A list of possible names will be provided.
- Sooo I added another `CommandType` called `PROMPTING`.